### PR TITLE
Upgrade react-onclickoutside to avoid React not defined errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "react-component-gulp-tasks": "^0.7.0"
   },
   "dependencies": {
+    "classnames": "^2.1.2",
     "lodash": ">=2.4.1",
     "react": ">=0.12.1",
-    "classnames": "^2.1.2",
-    "react-onclickoutside": "^0.2.4"
+    "react-onclickoutside": "^0.3.1"
   },
   "browserify-shim": {
     "classnames": "global:classNames",


### PR DESCRIPTION
Pull this in https://github.com/Pomax/react-onclickoutside/commit/0d1ddf1026ee7a3afada5c7d2e3b9736c7553ef6