### PR TITLE
Input element should not require focus when component is mounted

### DIFF
--- a/dist/react-telephone-input.js
+++ b/dist/react-telephone-input.js
@@ -3247,6 +3247,8 @@ var ReactTelephoneInput = React.createClass({
         var input = this.refs.numberInput.getDOMNode();
         if (!skipFocus) {
           input.focus();
+        } else {
+          this.handleInputFocus();
         }
         if (isModernBrowser) {
             var len = input.value.length;

--- a/dist/react-telephone-input.js
+++ b/dist/react-telephone-input.js
@@ -3163,7 +3163,7 @@ var ReactTelephoneInput = React.createClass({
     componentDidMount: function componentDidMount() {
         document.addEventListener('keydown', this.handleKeydown);
 
-        this._cursorToEnd();
+        this._cursorToEnd(true);
         if (typeof this.props.onChange === 'function') {
             this.props.onChange(this.state.formattedNumber);
         }
@@ -3243,9 +3243,11 @@ var ReactTelephoneInput = React.createClass({
     },
 
     // put the cursor to the end of the input (usually after a focus event)
-    _cursorToEnd: function _cursorToEnd() {
+    _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        input.focus();
+        if (!skipFocus) {
+          input.focus();
+        }
         if (isModernBrowser) {
             var len = input.value.length;
             input.setSelectionRange(len, len);

--- a/dist/react-telephone-input.js
+++ b/dist/react-telephone-input.js
@@ -3245,14 +3245,15 @@ var ReactTelephoneInput = React.createClass({
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        if (!skipFocus) {
-          input.focus();
-        } else {
+        if (skipFocus) {
           this.handleInputFocus();
-        }
-        if (isModernBrowser) {
-            var len = input.value.length;
-            input.setSelectionRange(len, len);
+        } else {
+          input.focus();
+
+          if (isModernBrowser) {
+              var len = input.value.length;
+              input.setSelectionRange(len, len);
+          }
         }
     },
     // memoize results based on the first 5/6 characters. That is all that matters

--- a/example/dist/bundle.js
+++ b/example/dist/bundle.js
@@ -3246,6 +3246,8 @@ var ReactTelephoneInput = React.createClass({
         var input = this.refs.numberInput.getDOMNode();
         if (!skipFocus) {
           input.focus();
+        } else {
+          this.handleInputFocus();
         }
         if (isModernBrowser) {
             var len = input.value.length;

--- a/example/dist/bundle.js
+++ b/example/dist/bundle.js
@@ -3162,7 +3162,7 @@ var ReactTelephoneInput = React.createClass({
     componentDidMount: function componentDidMount() {
         document.addEventListener('keydown', this.handleKeydown);
 
-        this._cursorToEnd();
+        this._cursorToEnd(true);
         if (typeof this.props.onChange === 'function') {
             this.props.onChange(this.state.formattedNumber);
         }
@@ -3242,9 +3242,11 @@ var ReactTelephoneInput = React.createClass({
     },
 
     // put the cursor to the end of the input (usually after a focus event)
-    _cursorToEnd: function _cursorToEnd() {
+    _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        input.focus();
+        if (!skipFocus) {
+          input.focus();
+        }
         if (isModernBrowser) {
             var len = input.value.length;
             input.setSelectionRange(len, len);

--- a/example/dist/bundle.js
+++ b/example/dist/bundle.js
@@ -3244,14 +3244,15 @@ var ReactTelephoneInput = React.createClass({
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        if (!skipFocus) {
-          input.focus();
-        } else {
+        if (skipFocus) {
           this.handleInputFocus();
-        }
-        if (isModernBrowser) {
-            var len = input.value.length;
-            input.setSelectionRange(len, len);
+        } else {
+          input.focus();
+
+          if (isModernBrowser) {
+              var len = input.value.length;
+              input.setSelectionRange(len, len);
+          }
         }
     },
     // memoize results based on the first 5/6 characters. That is all that matters

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,14 +190,15 @@ var ReactTelephoneInput = React.createClass({
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        if (!skipFocus) {
-          input.focus();
-        } else {
+        if (skipFocus) {
           this.handleInputFocus();
-        }
-        if (isModernBrowser) {
-            var len = input.value.length;
-            input.setSelectionRange(len, len);
+        } else {
+          input.focus();
+
+          if (isModernBrowser) {
+              var len = input.value.length;
+              input.setSelectionRange(len, len);
+          }
         }
     },
     // memoize results based on the first 5/6 characters. That is all that matters

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,7 @@ var ReactTelephoneInput = React.createClass({
     componentDidMount: function componentDidMount() {
         document.addEventListener('keydown', this.handleKeydown);
 
-        this._cursorToEnd();
+        this._cursorToEnd(true);
         if (typeof this.props.onChange === 'function') {
             this.props.onChange(this.state.formattedNumber);
         }
@@ -188,9 +188,11 @@ var ReactTelephoneInput = React.createClass({
     },
 
     // put the cursor to the end of the input (usually after a focus event)
-    _cursorToEnd: function _cursorToEnd() {
+    _cursorToEnd: function _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        input.focus();
+        if (!skipFocus) {
+          input.focus();
+        }
         if (isModernBrowser) {
             var len = input.value.length;
             input.setSelectionRange(len, len);

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,8 @@ var ReactTelephoneInput = React.createClass({
         var input = this.refs.numberInput.getDOMNode();
         if (!skipFocus) {
           input.focus();
+        } else {
+          this.handleInputFocus();
         }
         if (isModernBrowser) {
             var len = input.value.length;

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ var ReactTelephoneInput = React.createClass({
     componentDidMount() {
         document.addEventListener('keydown', this.handleKeydown);
 
-        this._cursorToEnd();
+        this._cursorToEnd(true);
         if(typeof this.props.onChange === 'function') {
             this.props.onChange(this.state.formattedNumber);
         }
@@ -186,9 +186,11 @@ var ReactTelephoneInput = React.createClass({
     },
 
     // put the cursor to the end of the input (usually after a focus event)
-    _cursorToEnd() {
+    _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        input.focus();
+        if (!skipFocus) {
+          input.focus();
+        }
         if (isModernBrowser) {
             var len = input.value.length;
             input.setSelectionRange(len, len);

--- a/src/index.js
+++ b/src/index.js
@@ -188,14 +188,15 @@ var ReactTelephoneInput = React.createClass({
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput.getDOMNode();
-        if (!skipFocus) {
-          input.focus();
-        } else {
+        if (skipFocus) {
           this.handleInputFocus();
-        }
-        if (isModernBrowser) {
-            var len = input.value.length;
-            input.setSelectionRange(len, len);
+        } else {
+          input.focus();
+
+          if (isModernBrowser) {
+              var len = input.value.length;
+              input.setSelectionRange(len, len);
+          }
         }
     },
     // memoize results based on the first 5/6 characters. That is all that matters

--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,8 @@ var ReactTelephoneInput = React.createClass({
         var input = this.refs.numberInput.getDOMNode();
         if (!skipFocus) {
           input.focus();
+        } else {
+          this.handleInputFocus();
         }
         if (isModernBrowser) {
             var len = input.value.length;


### PR DESCRIPTION
It is generally a bad idea to force set the input field's focus. This skips input field focus when component is mounted, instead triggering the associated onFocus handler event.