### PR TITLE
Fix lodash dependency to ^3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
-    "lodash": ">=2.4.1",
+    "lodash": "^3.10.1",
     "react": ">=0.14.0",
     "react-dom": "^0.14.7",
     "react-onclickoutside": "^4.5.0"


### PR DESCRIPTION
I tried to clone and build but it failed because I ended up getting lodash 4. I found that I could build with lodash 3 though.

This PR changes fixes the lodash dependency to version 3. Later on it might be worth updating to lodash 4, but this PR alone should make the project buildable again.