### PR TITLE
Move caret to correct place if user does a select all and types

### DIFF
--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -279,6 +279,10 @@ var ReactTelephoneInput = React.createClass({
             selectedCountry: newSelectedCountry.dialCode.length > 0 ? newSelectedCountry : this.state.selectedCountry
         }, function() {
             if(isModernBrowser) {
+                if((caretPosition == 1) && (formattedNumber.length == 2)) {
+                    caretPosition++;
+                }
+
                 if(diff > 0) {
                     caretPosition = caretPosition - diff;
                 }


### PR DESCRIPTION
If the caret position is 1 and the length is two, then the only caret position that makes sense is 2, so we set it to that. This happens after doing a select all and typing or if a number is entered when the phone number just says '+'.