### PR TITLE
Added onFocus event handler as a component prop

### DIFF
--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -83,9 +83,11 @@ var ReactTelephoneInput = React.createClass({
         defaultCountry: React.PropTypes.string,
         onlyCountries: React.PropTypes.arrayOf(React.PropTypes.object),
         preferredCountries: React.PropTypes.arrayOf(React.PropTypes.string),
+        classNames: React.PropTypes.string,
         onChange: React.PropTypes.func,
         onEnterKeyPress: React.PropTypes.func,
-        classNames: React.PropTypes.string
+        onBlur: React.PropTypes.func,
+        onFocus: React.PropTypes.func
     },
     getDefaultProps() {
         return {
@@ -327,9 +329,18 @@ var ReactTelephoneInput = React.createClass({
         }
     },
     handleInputFocus() {
+        var formattedNumer = this.state.formattedNumer;
+        var selectedCountry = this.state.selectedCountry;
+
         // if the input is blank, insert dial code of the selected country
         if(this.refs.numberInput.value === '+') {
-            this.setState({formattedNumber: '+' + this.state.selectedCountry.dialCode});
+            formattedNumer = '+' + selectedCountry.dialCode;
+            this.setState({formattedNumber: formattedNumer});
+        }
+
+        // trigger parent component's onFocus handler
+        if(typeof this.props.onFocus === 'function') {
+            this.props.onFocus(formattedNumer, selectedCountry);
         }
     },
     _getHighlightCountryIndex(direction) {

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -194,7 +194,7 @@ var ReactTelephoneInput = React.createClass({
     _cursorToEnd(skipFocus) {
         var input = this.refs.numberInput;
         if (skipFocus) {
-            this.handleInputFocus();
+            this._fillDialCode();
         } else {
             input.focus();
 
@@ -329,18 +329,17 @@ var ReactTelephoneInput = React.createClass({
         }
     },
     handleInputFocus() {
-        var formattedNumer = this.state.formattedNumer;
-        var selectedCountry = this.state.selectedCountry;
-
-        // if the input is blank, insert dial code of the selected country
-        if(this.refs.numberInput.value === '+') {
-            formattedNumer = '+' + selectedCountry.dialCode;
-            this.setState({formattedNumber: formattedNumer});
-        }
-
         // trigger parent component's onFocus handler
         if(typeof this.props.onFocus === 'function') {
-            this.props.onFocus(formattedNumer, selectedCountry);
+            this.props.onFocus(this.state.formattedNumer, this.state.selectedCountry);
+        }
+
+        this._fillDialCode();
+    },
+    _fillDialCode() {
+        // if the input is blank, insert dial code of the selected country
+        if(this.refs.numberInput.value === '+') {
+            this.setState({formattedNumber: '+' + this.state.selectedCountry.dialCode});
         }
     },
     _getHighlightCountryIndex(direction) {

--- a/test/ReactTelephoneInput-test.js
+++ b/test/ReactTelephoneInput-test.js
@@ -55,4 +55,30 @@ describe('react telephone input', function() {
         // select the first one if not able to resolve completely
         expect(rti.guessSelectedCountry('59').iso2).to.equal(allCountries[0].iso2);
     });
+
+    it('should trigger onFocus event handler when input element is focused', (done) => {
+        const onFocus = (number, country) => {
+            expect(number).to.be.a.string;
+            expect(country).to.be.string;
+            done();
+        };
+
+        rti = TestUtils.renderIntoDocument(React.createElement(ReactTelephoneInput, {onFocus}));
+        expect(rti).to.be.defined;
+
+        TestUtils.Simulate.focus(rti.refs.numberInput);
+    });
+
+    it('should trigger onBlur event handler when input element is unfocused', (done) => {
+        const onBlur = (number, country) => {
+            expect(number).to.be.a.string;
+            expect(country).to.be.string;
+            done();
+        };
+
+        rti = TestUtils.renderIntoDocument(React.createElement(ReactTelephoneInput, {onBlur}));
+        expect(rti).to.be.defined;
+
+        TestUtils.Simulate.blur(rti.refs.numberInput);
+    });
 });


### PR DESCRIPTION
Parent components can pass in an event handler function to the ReactTelephoneInput component as a prop like so:
```
<ReactTelephoneInput onFocus={() => {this.setFocused();}} onBlur={() => {this.setFocused(false);}} ... />
```