### PR TITLE
Handle disabled attribute

### DIFF
--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -81,7 +81,8 @@ function isNumberValid(inputNumber) {
         onChange: React.PropTypes.func,
         onEnterKeyPress: React.PropTypes.func,
         onBlur: React.PropTypes.func,
-        onFocus: React.PropTypes.func
+        onFocus: React.PropTypes.func,
+        disabled: React.PropTypes.bool
     },
     getDefaultProps() {
         return {
@@ -234,6 +235,9 @@ function isNumberValid(inputNumber) {
         return ReactDOM.findDOMNode(this.refs[`flag_no_${index}`]);
     },
     handleFlagDropdownClick() {
+        if (this.props.disabled) {
+          return;
+        }
         // need to put the highlight on the current selected country if the dropdown is going to open up
         this.setState({
             showDropDown: !this.state.showDropDown,
@@ -525,7 +529,8 @@ function isNumberValid(inputNumber) {
                     type="tel"
                     className={inputClasses}
                     autoComplete='tel'
-                    placeholder='+1 (702) 123-4567'/>
+                    placeholder='+1 (702) 123-4567'
+                    disabled={this.props.disabled}/>
                 <div ref='flagDropDownButton' className={flagViewClasses} onKeyDown={this.handleKeydown} >
                     <div ref='selectedFlag' onClick={this.handleFlagDropdownClick} className='selected-flag' title={`${this.state.selectedCountry.name}: + ${this.state.selectedCountry.dialCode}`}>
                         <div className={inputFlagClasses} style={this.getFlagStyle()}>


### PR DESCRIPTION
Passing `disabled` makes the input disabled and prevents the dropdown from activating so the prefix can't be updated.

This is similar to #81, but without `placeholder` and prevents the dropdown from opening which #81 does not.