### PR TITLE
Add pattern attribute

### DIFF
--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -81,7 +81,8 @@ function isNumberValid(inputNumber) {
         onChange: React.PropTypes.func,
         onEnterKeyPress: React.PropTypes.func,
         onBlur: React.PropTypes.func,
-        onFocus: React.PropTypes.func
+        onFocus: React.PropTypes.func,
+        pattern: React.PropTypes.string
     },
     getDefaultProps() {
         return {
@@ -525,6 +526,7 @@ function isNumberValid(inputNumber) {
                     type="tel"
                     className={inputClasses}
                     autoComplete='tel'
+                    pattern={this.props.pattern}
                     placeholder='+1 (702) 123-4567'/>
                 <div ref='flagDropDownButton' className={flagViewClasses} onKeyDown={this.handleKeydown} >
                     <div ref='selectedFlag' onClick={this.handleFlagDropdownClick} className='selected-flag' title={`${this.state.selectedCountry.name}: + ${this.state.selectedCountry.dialCode}`}>


### PR DESCRIPTION
I'd like to pass a pattern for browser validation if available (in my case it would just be `\+.+` to make sure the input isn't empty.

This is similar to #87 where it is passing the attribute to the input (although #87 has a bit more logic). Do you have a preference between passing specific attributes as props **or** passing a something like an`inputAttributes` object that is just spread on the object?