### PR TITLE
Fix for issue #103 - Canadian flag cannot be selected.

### DIFF
--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -217,8 +217,8 @@ var ReactTelephoneInput = React.createClass({
     },
     guessSelectedCountry: function(inputNumber) {
         // Fix for issue #103: When selecting Canada flag, guessSelectedCountry immediately switches it back to US flag.
-        // Issue arrises because both US and Canada share country code 1, and memoize stores this result.
-        if (inputNumber === '1') {
+        // Issue arises because both US and Canada share country code 1, and memoize stores this result.
+        if (this.state !== null && inputNumber.length < 2) {
             return this.state.selectedCountry;
         }
         return this.guessSelectedCountryWithMemoize(inputNumber);
@@ -285,8 +285,8 @@ var ReactTelephoneInput = React.createClass({
     },
     handleInput: function handleInput(event) {
         var formattedNumber = '+',
-            newSelectedCountry = this.state.selectedCountry,
-            freezeSelection = this.state.freezeSelection;
+          newSelectedCountry = this.state.selectedCountry,
+          freezeSelection = this.state.freezeSelection;
 
         // if the input is the same as before, must be some special key like enter etc.
         if (event.target.value === this.state.formattedNumber) {
@@ -504,26 +504,26 @@ var ReactTelephoneInput = React.createClass({
             var inputFlagClasses = 'flag ' + country.iso2;
 
             return React.createElement(
-                'li',
-                {
-                    ref: 'flag_no_' + index,
-                    key: 'flag_no_' + index,
-                    'data-flag-key': 'flag_no_' + index,
-                    className: itemClasses,
-                    'data-dial-code': '1',
-                    'data-country-code': country.iso2,
-                    onClick: this.handleFlagItemClick.bind(this, country) },
-                React.createElement('div', { className: inputFlagClasses, style: this.getFlagStyle() }),
-                React.createElement(
-                    'span',
-                    { className: 'country-name' },
-                    country.name
-                ),
-                React.createElement(
-                    'span',
-                    { className: 'dial-code' },
-                    '+' + country.dialCode
-                )
+              'li',
+              {
+                  ref: 'flag_no_' + index,
+                  key: 'flag_no_' + index,
+                  'data-flag-key': 'flag_no_' + index,
+                  className: itemClasses,
+                  'data-dial-code': '1',
+                  'data-country-code': country.iso2,
+                  onClick: this.handleFlagItemClick.bind(this, country) },
+              React.createElement('div', { className: inputFlagClasses, style: this.getFlagStyle() }),
+              React.createElement(
+                'span',
+                { className: 'country-name' },
+                country.name
+              ),
+              React.createElement(
+                'span',
+                { className: 'dial-code' },
+                '+' + country.dialCode
+              )
             );
         }, this);
 
@@ -536,9 +536,9 @@ var ReactTelephoneInput = React.createClass({
             'hide': !this.state.showDropDown
         });
         return React.createElement(
-            'ul',
-            { ref: 'flagDropdownList', className: dropDownClasses },
-            countryDropDownList
+          'ul',
+          { ref: 'flagDropdownList', className: dropDownClasses },
+          countryDropDownList
         );
     },
     getFlagStyle: function getFlagStyle() {
@@ -574,36 +574,36 @@ var ReactTelephoneInput = React.createClass({
             otherProps.id = this.props.inputId;
         }
         return React.createElement(
+          'div',
+          { className: classNames('react-tel-input', this.props.classNames) },
+          React.createElement('input', _extends({
+              onChange: this.handleInput,
+              onClick: this.handleInputClick,
+              onFocus: this.handleInputFocus,
+              onBlur: this.handleInputBlur,
+              onKeyDown: this.handleInputKeyDown,
+              value: this.state.formattedNumber,
+              ref: 'numberInput',
+              type: 'tel',
+              className: inputClasses,
+              autoComplete: 'tel',
+              pattern: this.props.pattern,
+              placeholder: this.state.placeholder,
+              disabled: this.props.disabled }, otherProps)),
+          React.createElement(
             'div',
-            { className: classNames('react-tel-input', this.props.classNames) },
-            React.createElement('input', _extends({
-                onChange: this.handleInput,
-                onClick: this.handleInputClick,
-                onFocus: this.handleInputFocus,
-                onBlur: this.handleInputBlur,
-                onKeyDown: this.handleInputKeyDown,
-                value: this.state.formattedNumber,
-                ref: 'numberInput',
-                type: 'tel',
-                className: inputClasses,
-                autoComplete: 'tel',
-                pattern: this.props.pattern,
-                placeholder: this.state.placeholder,
-                disabled: this.props.disabled }, otherProps)),
+            { ref: 'flagDropDownButton', className: flagViewClasses, onKeyDown: this.handleKeydown },
             React.createElement(
+              'div',
+              { ref: 'selectedFlag', onClick: this.handleFlagDropdownClick, className: 'selected-flag', title: this.state.selectedCountry.name + ': + ' + this.state.selectedCountry.dialCode },
+              React.createElement(
                 'div',
-                { ref: 'flagDropDownButton', className: flagViewClasses, onKeyDown: this.handleKeydown },
-                React.createElement(
-                    'div',
-                    { ref: 'selectedFlag', onClick: this.handleFlagDropdownClick, className: 'selected-flag', title: this.state.selectedCountry.name + ': + ' + this.state.selectedCountry.dialCode },
-                    React.createElement(
-                        'div',
-                        { className: inputFlagClasses, style: this.getFlagStyle() },
-                        React.createElement('div', { className: arrowClasses })
-                    )
-                ),
-                this.state.showDropDown ? this.getCountryDropDownList() : ''
-            )
+                { className: inputFlagClasses, style: this.getFlagStyle() },
+                React.createElement('div', { className: arrowClasses })
+              )
+            ),
+            this.state.showDropDown ? this.getCountryDropDownList() : ''
+          )
         );
     }
 });

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -215,8 +215,16 @@ var ReactTelephoneInput = React.createClass({
             }
         }
     },
+    guessSelectedCountry: function(inputNumber) {
+        // Fix for issue #103: When selecting Canada flag, guessSelectedCountry immediately switches it back to US flag.
+        // Issue arrises because both US and Canada share country code 1, and memoize stores this result.
+        if (inputNumber === '1') {
+            return this.state.selectedCountry;
+        }
+        return this.guessSelectedCountryWithMemoize(inputNumber);
+    },
     // memoize results based on the first 5/6 characters. That is all that matters
-    guessSelectedCountry: memoize(function (inputNumber) {
+    guessSelectedCountryWithMemoize: memoize(function (inputNumber) {
         var secondBestGuess = findWhere(allCountries, { iso2: this.props.defaultCountry }) || this.props.onlyCountries[0];
         var inputNumberForCountries = inputNumber.substr(0, 4);
         if (trim(inputNumber) !== '') {
@@ -229,19 +237,19 @@ var ReactTelephoneInput = React.createClass({
 
                     // if the selected country dialCode is there with the area code
                 } else if (allCountryCodes[inputNumberForCountries] && allCountryCodes[inputNumberForCountries][0] === selectedCountry.iso2) {
-                        return selectedCountry;
+                    return selectedCountry;
 
-                        // else do the original if statement
-                    } else {
-                            if (startsWith(inputNumber, country.dialCode)) {
-                                if (country.dialCode.length > selectedCountry.dialCode.length) {
-                                    return country;
-                                }
-                                if (country.dialCode.length === selectedCountry.dialCode.length && country.priority < selectedCountry.priority) {
-                                    return country;
-                                }
-                            }
+                    // else do the original if statement
+                } else {
+                    if (startsWith(inputNumber, country.dialCode)) {
+                        if (country.dialCode.length > selectedCountry.dialCode.length) {
+                            return country;
                         }
+                        if (country.dialCode.length === selectedCountry.dialCode.length && country.priority < selectedCountry.priority) {
+                            return country;
+                        }
+                    }
+                }
                 return selectedCountry;
             }, { dialCode: '', priority: 10001 }, this);
         } else {

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -210,8 +210,16 @@ function isNumberValid(inputNumber) {
             }
         }
     },
-    // memoize results based on the first 5/6 characters. That is all that matters
-    guessSelectedCountry: memoize(function(inputNumber) {
+    guessSelectedCountry: function(inputNumber) {
+          // Fix for issue #103: When selecting Canada flag, guessSelectedCountry immediately switches it back to US flag.
+          // Issue arises because both US and Canada share country code 1, and memoize stores this result.
+          if (this.state !== null && inputNumber.length < 2) {
+              return this.state.selectedCountry;
+          }
+          return this.guessSelectedCountryWithMemoize(inputNumber);
+      },
+      // memoize results based on the first 5/6 characters. That is all that matters
+      guessSelectedCountryWithMemoize: memoize(function (inputNumber) {
         var secondBestGuess = findWhere(allCountries, {iso2: this.props.defaultCountry}) || this.props.onlyCountries[0];
 	var inputNumberForCountries = inputNumber.substr(0, 4);
         if (trim(inputNumber) !== '') {

--- a/test/ReactTelephoneInput-test.js
+++ b/test/ReactTelephoneInput-test.js
@@ -45,15 +45,16 @@ describe('react telephone input', function() {
         expect(rti.guessSelectedCountry('').iso2).to.equal(allCountries[0].iso2);
 
         // if input value is sent, select appropriately
+        expect(rti.guessSelectedCountry('1').iso2).to.equal(allCountries[0].iso2); // only guess after 2 or more digits entered
         expect(rti.guessSelectedCountry('12').iso2).to.equal('us'); // based on priority
         expect(rti.guessSelectedCountry('12112121').iso2).to.equal('us');
         expect(rti.guessSelectedCountry('913212121').iso2).to.equal('in');
         expect(rti.guessSelectedCountry('237').iso2).to.equal('cm'); // based on priority
         expect(rti.guessSelectedCountry('599').iso2).to.equal('cw');
         expect(rti.guessSelectedCountry('590').iso2).to.equal('gp');
-	expect(rti.guessSelectedCountry('1403').iso2).to.equal('ca');
-	expect(rti.guessSelectedCountry('18005').iso2).to.equal('us');
-	expect(rti.guessSelectedCountry('1809').iso2).to.equal('do');
+        expect(rti.guessSelectedCountry('1403').iso2).to.equal('ca');
+        expect(rti.guessSelectedCountry('18005').iso2).to.equal('us');
+        expect(rti.guessSelectedCountry('1809').iso2).to.equal('do');
 
 
         // select the first one if not able to resolve completely
@@ -105,6 +106,42 @@ describe('react telephone input', function() {
       rti.handleFlagDropdownClick()
       expect(rti.state.highlightCountryIndex).to.equal(2)
       expect(rti.state.formattedNumber).to.equal('+355121345');
+    });
+
+    it('should not switch selectedCountry back to USA after Canada is selected and number is 1', () => {
+      var canada = {
+        name: '‬‎Canada',
+        iso2: 'ca',
+        dialCode: '1',
+        priority: 0
+      };
+      var unitedStates = {
+        name: 'United States',
+        iso2: 'us',
+        dialCode: '1',
+        priority: 0
+      };
+
+      // Setup ReactTelephoneInput with a fixed set of countries
+      // so we know the expected indexes for sure
+      rti = TestUtils.renderIntoDocument(React.createElement(ReactTelephoneInput, {
+        onlyCountries: [canada, unitedStates],
+        preferredCountries: [unitedStates.iso2],
+        initialValue: '+1',
+      }));
+
+
+      // Emulate clicking a country and opening the dropdown,
+      // then check if the state.selectedCountry.iso2 is correct
+      rti.handleFlagItemClick(canada)
+      rti.handleFlagDropdownClick()
+      expect(rti.state.selectedCountry.iso2).to.equal('ca');
+      expect(rti.state.formattedNumber).to.equal('+1');
+
+      rti.handleFlagItemClick(unitedStates)
+      rti.handleFlagDropdownClick()
+      expect(rti.state.selectedCountry.iso2).to.equal('us');
+      expect(rti.state.formattedNumber).to.equal('+1');
     });
 
     it('should trigger onFocus event handler when input element is focused', (done) => {


### PR DESCRIPTION
When selecting Canada flag, guessSelectedCountry immediately switches it back to US flag. Issue arrises because both US and Canada share country code 1, and memoize stores this result.