### PR TITLE
Pointing cursor to the end every-time onFocus is called.

### DIFF
--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -372,8 +372,8 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = React.createClass({
         if (typeof this.props.onFocus === 'function') {
             this.props.onFocus(this.state.formattedNumer, this.state.selectedCountry);
         }
-
         this._fillDialCode();
+        this._cursorToEnd();
     },
     _mapPropsToState: function _mapPropsToState(props) {
         var firstCall = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;


### PR DESCRIPTION
#122 Solved the open issue.
Everytime the onFocus function is called, the cursor would point to the end in-order to avoid editing of the current countryflag and code if the user starts typing immediately.