### PR TITLE
#153 hide + sign on empty input

### DIFF
--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -57,7 +57,7 @@ var keys = {
 
 function formatNumber(text, pattern, autoFormat) {
     if (!text || text.length === 0) {
-        return '+';
+        return '';
     }
 
     // for all strings with length less than 3, just return it (1, 2 etc.)


### PR DESCRIPTION
The simplest solution to #153 . Just remove the + on empty input.