### PR TITLE
Replace string ref usage with callback refs

### DIFF
--- a/es/ReactTelephoneInput.js
+++ b/es/ReactTelephoneInput.js
@@ -288,7 +288,7 @@ export var ReactTelephoneInput = createReactClass({
         return ReactDOM.findDOMNode(this.flagElems['flag_no_' + index]);
     },
     handleFlagDropdownClick: function handleFlagDropdownClick(e) {
-        var _this = this;
+        var _this2 = this;
 
         if (this.props.disabled) {
             return;
@@ -302,12 +302,14 @@ export var ReactTelephoneInput = createReactClass({
             highlightCountryIndex: findIndex(this.state.preferredCountries.concat(this.props.onlyCountries), this.state.selectedCountry)
         }, function () {
             // only need to scrool if the dropdown list is alive
-            if (_this.state.showDropDown) {
-                _this.scrollTo(_this.getElement(_this.state.highlightCountryIndex + _this.state.preferredCountries.length));
+            if (_this2.state.showDropDown) {
+                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex + _this2.state.preferredCountries.length));
             }
         });
     },
     handleInput: function handleInput(event) {
+        var _this3 = this;
+
         var formattedNumber = '+',
             newSelectedCountry = this.state.selectedCountry,
             freezeSelection = this.state.freezeSelection;
@@ -341,6 +343,7 @@ export var ReactTelephoneInput = createReactClass({
         var caretPosition = event.target.selectionStart;
         var oldFormattedText = this.state.formattedNumber;
         var diff = formattedNumber.length - oldFormattedText.length;
+        var _this = this;
 
         this.setState({
             formattedNumber: formattedNumber,
@@ -356,13 +359,13 @@ export var ReactTelephoneInput = createReactClass({
                     caretPosition = caretPosition - diff;
                 }
 
-                if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
-                    this.numberInput.setSelectionRange(caretPosition, caretPosition);
+                if (_this3.numberInput && caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
+                    _this3.numberInput.setSelectionRange(caretPosition, caretPosition);
                 }
             }
 
-            if (this.props.onChange) {
-                this.props.onChange(this.state.formattedNumber, this.state.selectedCountry);
+            if (_this3.props.onChange) {
+                _this3.props.onChange(_this3.state.formattedNumber, _this3.state.selectedCountry);
             }
         });
     },

--- a/es/ReactTelephoneInput.js
+++ b/es/ReactTelephoneInput.js
@@ -303,7 +303,7 @@ export var ReactTelephoneInput = createReactClass({
         }, function () {
             // only need to scrool if the dropdown list is alive
             if (_this2.state.showDropDown) {
-                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex + _this2.state.preferredCountries.length));
+                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex));
             }
         });
     },

--- a/es/ReactTelephoneInput.js
+++ b/es/ReactTelephoneInput.js
@@ -136,6 +136,9 @@ export var ReactTelephoneInput = createReactClass({
         required: PropTypes.bool,
         inputProps: PropTypes.object
     },
+    flagDropdownList: null,
+    numberInput: null,
+    flagElems: {},
     getDefaultProps: function getDefaultProps() {
         return {
             autoFormat: true,
@@ -180,7 +183,7 @@ export var ReactTelephoneInput = createReactClass({
             return;
         }
 
-        var container = ReactDOM.findDOMNode(this.refs.flagDropdownList);
+        var container = ReactDOM.findDOMNode(this.flagDropdownList);
 
         if (!container) {
             return;
@@ -219,7 +222,12 @@ export var ReactTelephoneInput = createReactClass({
 
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd: function _cursorToEnd(skipFocus) {
-        var input = this.refs.numberInput;
+        var input = this.numberInput;
+
+        if (!input) {
+            return;
+        }
+
         if (skipFocus) {
             this._fillDialCode();
         } else {
@@ -271,7 +279,7 @@ export var ReactTelephoneInput = createReactClass({
         return bestGuess;
     },
     getElement: function getElement(index) {
-        return ReactDOM.findDOMNode(this.refs['flag_no_' + index]);
+        return ReactDOM.findDOMNode(this.flagElems['flag_no_' + index]);
     },
     handleFlagDropdownClick: function handleFlagDropdownClick(e) {
         var _this = this;
@@ -343,7 +351,7 @@ export var ReactTelephoneInput = createReactClass({
                 }
 
                 if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
-                    this.refs.numberInput.setSelectionRange(caretPosition, caretPosition);
+                    this.numberInput.setSelectionRange(caretPosition, caretPosition);
                 }
             }
 
@@ -419,7 +427,7 @@ export var ReactTelephoneInput = createReactClass({
     },
     _fillDialCode: function _fillDialCode() {
         // if the input is blank, insert dial code of the selected country
-        if (this.refs.numberInput.value === '+') {
+        if (this.numberInput && this.numberInput.value === '+') {
             this.setState({
                 formattedNumber: '+' + this.state.selectedCountry.dialCode
             });
@@ -511,6 +519,10 @@ export var ReactTelephoneInput = createReactClass({
             });
         }
     },
+    setFlagElem: function setFlagElem(elem, index) {
+        var key = 'flag_no_' + index;
+        this.flagElems[key] = elem;
+    },
     getCountryDropDownList: function getCountryDropDownList() {
         var self = this;
         var countryDropDownList = map(this.state.preferredCountries.concat(this.props.onlyCountries), function (country, index) {
@@ -527,7 +539,9 @@ export var ReactTelephoneInput = createReactClass({
             return React.createElement(
                 'li',
                 {
-                    ref: 'flag_no_' + index,
+                    ref: function ref(elem) {
+                        return self.setFlagElem(elem, index);
+                    },
                     key: 'flag_no_' + index,
                     'data-flag-key': 'flag_no_' + index,
                     className: itemClasses,
@@ -562,9 +576,12 @@ export var ReactTelephoneInput = createReactClass({
         });
         return React.createElement(
             'ul',
-            { ref: 'flagDropdownList', className: dropDownClasses },
+            { ref: this.setFlagDropdownList, className: dropDownClasses },
             countryDropDownList
         );
+    },
+    setFlagDropdownList: function setFlagDropdownList(elem) {
+        this.flagDropdownList = elem;
     },
     getFlagStyle: function getFlagStyle() {
         return {
@@ -577,6 +594,9 @@ export var ReactTelephoneInput = createReactClass({
         if (typeof this.props.onBlur === 'function') {
             this.props.onBlur(this.state.formattedNumber, this.state.selectedCountry);
         }
+    },
+    setNumberInput: function setNumberInput(elem) {
+        this.numberInput = elem;
     },
     render: function render() {
         var arrowClasses = classNames({
@@ -610,7 +630,7 @@ export var ReactTelephoneInput = createReactClass({
                 onBlur: this.handleInputBlur,
                 onKeyDown: this.handleInputKeyDown,
                 value: this.state.formattedNumber,
-                ref: 'numberInput',
+                ref: this.setNumberInput,
                 type: 'tel',
                 className: inputClasses,
                 autoComplete: this.props.autoComplete,
@@ -622,14 +642,12 @@ export var ReactTelephoneInput = createReactClass({
             React.createElement(
                 'div',
                 {
-                    ref: 'flagDropDownButton',
                     className: flagViewClasses,
                     onKeyDown: this.handleKeydown
                 },
                 React.createElement(
                     'div',
                     {
-                        ref: 'selectedFlag',
                         onClick: this.handleFlagDropdownClick,
                         className: 'selected-flag',
                         title: this.state.selectedCountry.name + ': + ' + this.state.selectedCountry.dialCode

--- a/es/ReactTelephoneInput.js
+++ b/es/ReactTelephoneInput.js
@@ -173,7 +173,13 @@ export var ReactTelephoneInput = createReactClass({
         return !isEqual(nextProps, this.props) || !isEqual(nextState, this.state);
     },
     componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-        this.setState(this._mapPropsToState(nextProps));
+        var prevFormattedNumber = this.state.formattedNumber;
+        this.setState(this._mapPropsToState(nextProps), function () {
+            // If formatted number has changed, call on change
+            if (this.state.formattedNumber !== prevFormattedNumber) {
+                this.props.onChange(this.state.formattedNumber, this.state.selectedCountry);
+            }
+        });
     },
     componentWillUnmount: function componentWillUnmount() {
         document.removeEventListener('keydown', this.handleKeydown);

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -310,7 +310,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         }, function () {
             // only need to scrool if the dropdown list is alive
             if (_this2.state.showDropDown) {
-                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex + _this2.state.preferredCountries.length));
+                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex));
             }
         });
     },

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -295,7 +295,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         return ReactDOM.findDOMNode(this.flagElems['flag_no_' + index]);
     },
     handleFlagDropdownClick: function handleFlagDropdownClick(e) {
-        var _this = this;
+        var _this2 = this;
 
         if (this.props.disabled) {
             return;
@@ -309,12 +309,14 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
             highlightCountryIndex: findIndex(this.state.preferredCountries.concat(this.props.onlyCountries), this.state.selectedCountry)
         }, function () {
             // only need to scrool if the dropdown list is alive
-            if (_this.state.showDropDown) {
-                _this.scrollTo(_this.getElement(_this.state.highlightCountryIndex + _this.state.preferredCountries.length));
+            if (_this2.state.showDropDown) {
+                _this2.scrollTo(_this2.getElement(_this2.state.highlightCountryIndex + _this2.state.preferredCountries.length));
             }
         });
     },
     handleInput: function handleInput(event) {
+        var _this3 = this;
+
         var formattedNumber = '+',
             newSelectedCountry = this.state.selectedCountry,
             freezeSelection = this.state.freezeSelection;
@@ -348,6 +350,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         var caretPosition = event.target.selectionStart;
         var oldFormattedText = this.state.formattedNumber;
         var diff = formattedNumber.length - oldFormattedText.length;
+        var _this = this;
 
         this.setState({
             formattedNumber: formattedNumber,
@@ -363,13 +366,13 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
                     caretPosition = caretPosition - diff;
                 }
 
-                if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
-                    this.numberInput.setSelectionRange(caretPosition, caretPosition);
+                if (_this3.numberInput && caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
+                    _this3.numberInput.setSelectionRange(caretPosition, caretPosition);
                 }
             }
 
-            if (this.props.onChange) {
-                this.props.onChange(this.state.formattedNumber, this.state.selectedCountry);
+            if (_this3.props.onChange) {
+                _this3.props.onChange(_this3.state.formattedNumber, _this3.state.selectedCountry);
             }
         });
     },

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -143,6 +143,9 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         required: PropTypes.bool,
         inputProps: PropTypes.object
     },
+    flagDropdownList: null,
+    numberInput: null,
+    flagElems: {},
     getDefaultProps: function getDefaultProps() {
         return {
             autoFormat: true,
@@ -187,7 +190,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
             return;
         }
 
-        var container = ReactDOM.findDOMNode(this.refs.flagDropdownList);
+        var container = ReactDOM.findDOMNode(this.flagDropdownList);
 
         if (!container) {
             return;
@@ -226,7 +229,12 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
 
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd: function _cursorToEnd(skipFocus) {
-        var input = this.refs.numberInput;
+        var input = this.numberInput;
+
+        if (!input) {
+            return;
+        }
+
         if (skipFocus) {
             this._fillDialCode();
         } else {
@@ -278,7 +286,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         return bestGuess;
     },
     getElement: function getElement(index) {
-        return ReactDOM.findDOMNode(this.refs['flag_no_' + index]);
+        return ReactDOM.findDOMNode(this.flagElems['flag_no_' + index]);
     },
     handleFlagDropdownClick: function handleFlagDropdownClick(e) {
         var _this = this;
@@ -350,7 +358,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
                 }
 
                 if (caretPosition > 0 && oldFormattedText.length >= formattedNumber.length) {
-                    this.refs.numberInput.setSelectionRange(caretPosition, caretPosition);
+                    this.numberInput.setSelectionRange(caretPosition, caretPosition);
                 }
             }
 
@@ -426,7 +434,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
     },
     _fillDialCode: function _fillDialCode() {
         // if the input is blank, insert dial code of the selected country
-        if (this.refs.numberInput.value === '+') {
+        if (this.numberInput && this.numberInput.value === '+') {
             this.setState({
                 formattedNumber: '+' + this.state.selectedCountry.dialCode
             });
@@ -518,6 +526,10 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
             });
         }
     },
+    setFlagElem: function setFlagElem(elem, index) {
+        var key = 'flag_no_' + index;
+        this.flagElems[key] = elem;
+    },
     getCountryDropDownList: function getCountryDropDownList() {
         var self = this;
         var countryDropDownList = map(this.state.preferredCountries.concat(this.props.onlyCountries), function (country, index) {
@@ -534,7 +546,9 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
             return React.createElement(
                 'li',
                 {
-                    ref: 'flag_no_' + index,
+                    ref: function ref(elem) {
+                        return self.setFlagElem(elem, index);
+                    },
                     key: 'flag_no_' + index,
                     'data-flag-key': 'flag_no_' + index,
                     className: itemClasses,
@@ -569,9 +583,12 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         });
         return React.createElement(
             'ul',
-            { ref: 'flagDropdownList', className: dropDownClasses },
+            { ref: this.setFlagDropdownList, className: dropDownClasses },
             countryDropDownList
         );
+    },
+    setFlagDropdownList: function setFlagDropdownList(elem) {
+        this.flagDropdownList = elem;
     },
     getFlagStyle: function getFlagStyle() {
         return {
@@ -584,6 +601,9 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         if (typeof this.props.onBlur === 'function') {
             this.props.onBlur(this.state.formattedNumber, this.state.selectedCountry);
         }
+    },
+    setNumberInput: function setNumberInput(elem) {
+        this.numberInput = elem;
     },
     render: function render() {
         var arrowClasses = classNames({
@@ -617,7 +637,7 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
                 onBlur: this.handleInputBlur,
                 onKeyDown: this.handleInputKeyDown,
                 value: this.state.formattedNumber,
-                ref: 'numberInput',
+                ref: this.setNumberInput,
                 type: 'tel',
                 className: inputClasses,
                 autoComplete: this.props.autoComplete,
@@ -629,14 +649,12 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
             React.createElement(
                 'div',
                 {
-                    ref: 'flagDropDownButton',
                     className: flagViewClasses,
                     onKeyDown: this.handleKeydown
                 },
                 React.createElement(
                     'div',
                     {
-                        ref: 'selectedFlag',
                         onClick: this.handleFlagDropdownClick,
                         className: 'selected-flag',
                         title: this.state.selectedCountry.name + ': + ' + this.state.selectedCountry.dialCode

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -180,7 +180,13 @@ var ReactTelephoneInput = exports.ReactTelephoneInput = createReactClass({
         return !isEqual(nextProps, this.props) || !isEqual(nextState, this.state);
     },
     componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-        this.setState(this._mapPropsToState(nextProps));
+        var prevFormattedNumber = this.state.formattedNumber;
+        this.setState(this._mapPropsToState(nextProps), function () {
+            // If formatted number has changed, call on change
+            if (this.state.formattedNumber !== prevFormattedNumber) {
+                this.props.onChange(this.state.formattedNumber, this.state.selectedCountry);
+            }
+        });
     },
     componentWillUnmount: function componentWillUnmount() {
         document.removeEventListener('keydown', this.handleKeydown);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-telephone-input",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -290,11 +290,6 @@
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
-    },
-    "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
@@ -4267,6 +4262,12 @@
         }
       }
     },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha1-TLiDLSNhJYmwQG6eKVbBfwb99TE=",
+      "dev": true
+    },
     "buffer-indexof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz",
@@ -4391,13 +4392,45 @@
       }
     },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      },
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.1.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/assertion-error/-/assertion-error-1.1.0.tgz",
+          "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+          "dev": true
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
+        }
       }
     },
     "chalk": {
@@ -4587,7 +4620,8 @@
       }
     },
     "classnames": {
-      "version": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "version": "2.2.5",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
     "clean-css": {
@@ -4620,11 +4654,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.0.0.tgz",
       "integrity": "sha1-75h+09SDkaw9q5GAtAanQhgNbmo=",
-      "dev": true
-    },
-    "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
       "dev": true
     },
     "cliui": {
@@ -4849,16 +4878,6 @@
       "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-      "dev": true,
-      "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-        "typedarray": "0.0.6"
-      }
     },
     "connect": {
       "version": "3.6.2",
@@ -5267,7 +5286,8 @@
       }
     },
     "country-telephone-data": {
-      "version": "https://registry.npmjs.org/country-telephone-data/-/country-telephone-data-0.4.2.tgz",
+      "version": "0.4.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/country-telephone-data/-/country-telephone-data-0.4.2.tgz",
       "integrity": "sha1-eAEkqnwKTEL8JqOI5WSMUIsCs6s="
     },
     "create-ecdh": {
@@ -5846,14 +5866,6 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
-    "d": {
-      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
-    },
     "dashdash": {
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
@@ -5897,21 +5909,6 @@
       "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
-      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -6079,7 +6076,8 @@
       }
     },
     "dirty-chai": {
-      "version": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-1.2.2.tgz",
+      "version": "1.2.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/dirty-chai/-/dirty-chai-1.2.2.tgz",
       "integrity": "sha1-eEleYZY19/5EIZqkyDeEm/GDFC4=",
       "dev": true
     },
@@ -6106,27 +6104,6 @@
       "dev": true,
       "requires": {
         "buffer-indexof": "1.1.0"
-      }
-    },
-    "doctrine": {
-      "version": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
-      "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
-      "dev": true,
-      "requires": {
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-      },
-      "dependencies": {
-        "esutils": {
-          "version": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
       }
     },
     "dom-converter": {
@@ -6489,75 +6466,11 @@
         "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
       }
     },
-    "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
-    },
-    "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
-    },
-    "es6-map": {
-      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-      "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-      }
-    },
     "es6-promise": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
       "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
       "dev": true
-    },
-    "es6-set": {
-      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-      "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-      }
-    },
-    "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
-    },
-    "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-      "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -6635,100 +6548,662 @@
         }
       }
     },
-    "escope": {
-      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+    "eslint": {
+      "version": "0.23.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/eslint/-/eslint-0.23.0.tgz",
+      "integrity": "sha1-mfZlOoJMXNNj9TkJ3Mjvl38S3hc=",
       "dev": true,
       "requires": {
-        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "0.6.4",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "2.0.0",
+        "estraverse-fb": "1.3.2",
+        "globals": "8.18.0",
+        "inquirer": "0.8.5",
+        "is-my-json-valid": "2.17.2",
+        "js-yaml": "3.11.0",
+        "minimatch": "2.0.10",
+        "mkdirp": "0.5.1",
+        "object-assign": "2.1.1",
+        "optionator": "0.5.0",
+        "path-is-absolute": "1.0.1",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "1.1.1",
+        "xml-escape": "1.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "1.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/cli-width/-/cli-width-1.1.1.tgz",
+          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.5",
+            "typedarray": "0.0.6"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.42"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "0.6.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/doctrine/-/doctrine-0.6.4.tgz",
+          "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            }
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.42",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es5-ext/-/es5-ext-0.10.42.tgz",
+          "integrity": "sha1-jAfdM68E1dzRMQtc7xO+pjqJuo0=",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "next-tick": "1.0.0"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es6-iterator/-/es6-iterator-2.0.3.tgz",
+          "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es6-map/-/es6-map-0.1.5.tgz",
+          "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-set": "0.1.5",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es6-set/-/es6-set-0.1.5.tgz",
+          "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+          "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "requires": {
+            "es6-map": "0.1.5",
+            "es6-weak-map": "2.0.2",
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "4.2.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/estraverse/-/estraverse-4.2.0.tgz",
+              "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+              "dev": true
+            }
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+          "dev": true
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/esrecurse/-/esrecurse-4.2.1.tgz",
+          "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+          "dev": true,
+          "requires": {
+            "estraverse": "4.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "4.2.0",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/estraverse/-/estraverse-4.2.0.tgz",
+              "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+              "dev": true
+            }
+          }
+        },
         "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/estraverse/-/estraverse-2.0.0.tgz",
+          "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE=",
+          "dev": true
+        },
+        "estraverse-fb": {
+          "version": "1.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+          "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/event-emitter/-/event-emitter-0.3.5.tgz",
+          "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.42"
+          }
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+          "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          },
+          "dependencies": {
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true
+            }
+          }
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/generate-function/-/generate-function-2.0.0.tgz",
+          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+          "dev": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+          "dev": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/inquirer/-/inquirer-0.8.5.tgz",
+          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "1.1.1",
+            "chalk": "1.1.3",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "0.1.1",
+            "rx": "2.5.3",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+              "dev": true
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.17.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+          "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
+          "dev": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "is-my-ip-valid": "1.0.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-property/-/is-property-1.0.2.tgz",
+          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.2.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/levn/-/levn-0.2.5.tgz",
+          "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "1.1.1"
+              }
+            }
+          }
+        },
+        "rx": {
+          "version": "2.5.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rx/-/rx-2.5.3.tgz",
+          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
-    "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
-      "integrity": "sha1-mfZlOoJMXNNj9TkJ3Mjvl38S3hc=",
-      "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
-        "estraverse-fb": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-        "xml-escape": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
-      },
-      "dependencies": {
-        "espree": {
-          "version": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
-          "dev": true
-        },
-        "globals": {
-          "version": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        }
-      }
+    "espree": {
+      "version": "2.2.5",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/espree/-/espree-2.2.5.tgz",
+      "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+      "dev": true
     },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
-    },
-    "esrecurse": {
-      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-      "dev": true,
-      "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
-      }
-    },
-    "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
-      "integrity": "sha1-WuRpYyQ2ACBmdMyySgnhZnT83KE=",
-      "dev": true
-    },
-    "estraverse-fb": {
-      "version": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
-      "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8=",
       "dev": true
     },
     "esutils": {
@@ -6741,15 +7216,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
       "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-      "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-      "dev": true,
-      "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
-      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -7125,11 +7591,6 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
-    "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-      "dev": true
-    },
     "fastparse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
@@ -7145,19 +7606,6 @@
         "websocket-driver": "0.6.5"
       }
     },
-    "fbjs": {
-      "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-      "integrity": "sha1-frZ9aYay1QB6m26S4OfLb3XK0pA=",
-      "dev": true,
-      "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "promise": "7.3.1",
-        "ua-parser-js": "0.7.13"
-      }
-    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -7165,15 +7613,6 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
-      }
-    },
-    "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
       }
     },
     "file-loader": {
@@ -9448,28 +9887,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-      "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-        "lodash": "4.17.4",
-        "readline2": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-        "rx": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-          "dev": true
-        }
-      }
-    },
     "internal-ip": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
@@ -9763,6 +10180,12 @@
       "requires": {
         "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
@@ -11806,15 +12229,6 @@
         "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
       }
     },
-    "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-      }
-    },
     "load-json-file": {
       "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
@@ -12633,14 +13047,6 @@
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
-    "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-      }
-    },
     "minimist": {
       "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
@@ -12858,11 +13264,6 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
-    "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-      "dev": true
-    },
     "nan": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
@@ -12888,6 +13289,12 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "no-case": {
@@ -13609,19 +14016,6 @@
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
-      }
-    },
-    "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-      "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-      "dev": true,
-      "requires": {
-        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
       }
     },
     "options": {
@@ -17693,13 +18087,54 @@
       }
     },
     "react": {
-      "version": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
-      "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY=",
+      "version": "15.6.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "dev": true,
       "requires": {
-        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        "create-react-class": "15.6.0",
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "react-addons-test-utils": {
@@ -17715,13 +18150,53 @@
       "dev": true
     },
     "react-dom": {
-      "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
-      "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo=",
+      "version": "15.6.2",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/react-dom/-/react-dom-15.6.2.tgz",
+      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "dev": true,
       "requires": {
-        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.6.tgz",
-        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.13"
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "react-onclickoutside": {
@@ -17903,30 +18378,6 @@
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "readline2": {
-      "version": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-      "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-      "dev": true,
-      "requires": {
-        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
           }
         }
       }
@@ -18417,11 +18868,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
       "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
-      "dev": true
-    },
-    "rx": {
-      "version": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-      "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
       "dev": true
     },
     "rx-lite": {
@@ -19226,11 +19672,6 @@
         "get-stdin": "4.0.1"
       }
     },
-    "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-      "dev": true
-    },
     "style-loader": {
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
@@ -19333,11 +19774,6 @@
         "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
       }
     },
-    "text-table": {
-      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
     "throat": {
       "version": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz",
       "integrity": "sha1-58ZMhny7OEXxCHdkL3tgBVuOwNY=",
@@ -19347,11 +19783,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "dev": true
-    },
-    "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
@@ -19529,11 +19960,6 @@
         "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
       }
     },
-    "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-      "dev": true
-    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -19608,8 +20034,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "uglifyjs-webpack-plugin": {
       "version": "0.4.6",
@@ -19731,11 +20156,6 @@
           "dev": true
         }
       }
-    },
-    "user-home": {
-      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
     },
     "useragent": {
       "version": "2.2.1",
@@ -21060,11 +21480,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
-      "dev": true
-    },
-    "xml-escape": {
-      "version": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
-      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
       "dev": true
     },
     "xml-name-validator": {

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -154,6 +154,9 @@ export var ReactTelephoneInput = createReactClass({
         required: PropTypes.bool,
         inputProps: PropTypes.object
     },
+    flagDropdownList: null,
+    numberInput: null,
+    flagElems: {},
     getDefaultProps() {
         return {
             autoFormat: true,
@@ -205,7 +208,7 @@ export var ReactTelephoneInput = createReactClass({
             return
         }
 
-        var container = ReactDOM.findDOMNode(this.refs.flagDropdownList)
+        var container = ReactDOM.findDOMNode(this.flagDropdownList)
 
         if (!container) {
             return
@@ -243,7 +246,12 @@ export var ReactTelephoneInput = createReactClass({
 
     // put the cursor to the end of the input (usually after a focus event)
     _cursorToEnd(skipFocus) {
-        var input = this.refs.numberInput
+        var input = this.numberInput;
+
+        if (!input) {
+            return;
+        }
+
         if (skipFocus) {
             this._fillDialCode()
         } else {
@@ -316,7 +324,7 @@ export var ReactTelephoneInput = createReactClass({
         return bestGuess
     },
     getElement(index) {
-        return ReactDOM.findDOMNode(this.refs[`flag_no_${index}`])
+        return ReactDOM.findDOMNode(this.flagElems[`flag_no_${index}`])
     },
     handleFlagDropdownClick(e) {
         if (this.props.disabled) {
@@ -419,7 +427,7 @@ export var ReactTelephoneInput = createReactClass({
                         caretPosition > 0 &&
                         oldFormattedText.length >= formattedNumber.length
                     ) {
-                        this.refs.numberInput.setSelectionRange(
+                        this.numberInput.setSelectionRange(
                             caretPosition,
                             caretPosition
                         )
@@ -529,7 +537,7 @@ export var ReactTelephoneInput = createReactClass({
     },
     _fillDialCode() {
         // if the input is blank, insert dial code of the selected country
-        if (this.refs.numberInput.value === '+') {
+        if (this.numberInput && this.numberInput.value === '+') {
             this.setState({
                 formattedNumber: '+' + this.state.selectedCountry.dialCode
             })
@@ -657,6 +665,10 @@ export var ReactTelephoneInput = createReactClass({
             })
         }
     },
+    setFlagElem(elem, index) {
+        const key = `flag_no_${index}`;
+        this.flagElems[key] = elem;
+    },
     getCountryDropDownList() {
         var self = this
         var countryDropDownList = map(
@@ -675,7 +687,7 @@ export var ReactTelephoneInput = createReactClass({
 
                 return (
                     <li
-                        ref={`flag_no_${index}`}
+                        ref={(elem) => self.setFlagElem(elem, index)}
                         key={`flag_no_${index}`}
                         data-flag-key={`flag_no_${index}`}
                         className={itemClasses}
@@ -711,10 +723,13 @@ export var ReactTelephoneInput = createReactClass({
             hide: !this.state.showDropDown
         })
         return (
-            <ul ref="flagDropdownList" className={dropDownClasses}>
+            <ul ref={this.setFlagDropdownList} className={dropDownClasses}>
                 {countryDropDownList}
             </ul>
         )
+    },
+    setFlagDropdownList(elem) {
+        this.flagDropdownList = elem;
     },
     getFlagStyle() {
         return {
@@ -730,6 +745,9 @@ export var ReactTelephoneInput = createReactClass({
                 this.state.selectedCountry
             )
         }
+    },
+    setNumberInput(elem) {
+        this.numberInput = elem;
     },
     render() {
         var arrowClasses = classNames({
@@ -768,7 +786,7 @@ export var ReactTelephoneInput = createReactClass({
                     onBlur={this.handleInputBlur}
                     onKeyDown={this.handleInputKeyDown}
                     value={this.state.formattedNumber}
-                    ref="numberInput"
+                    ref={this.setNumberInput}
                     type="tel"
                     className={inputClasses}
                     autoComplete={this.props.autoComplete}
@@ -779,12 +797,10 @@ export var ReactTelephoneInput = createReactClass({
                     {...otherProps}
                 />
                 <div
-                    ref="flagDropDownButton"
                     className={flagViewClasses}
                     onKeyDown={this.handleKeydown}
                 >
                     <div
-                        ref="selectedFlag"
                         onClick={this.handleFlagDropdownClick}
                         className="selected-flag"
                         title={`${this.state.selectedCountry.name}: + ${this

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -409,6 +409,7 @@ export var ReactTelephoneInput = createReactClass({
         var caretPosition = event.target.selectionStart
         var oldFormattedText = this.state.formattedNumber
         var diff = formattedNumber.length - oldFormattedText.length
+        var _this = this;
 
         this.setState(
             {
@@ -419,7 +420,7 @@ export var ReactTelephoneInput = createReactClass({
                         ? newSelectedCountry
                         : this.state.selectedCountry
             },
-            function() {
+            () => {
                 if (isModernBrowser) {
                     if (caretPosition === 1 && formattedNumber.length === 2) {
                         caretPosition++
@@ -430,6 +431,7 @@ export var ReactTelephoneInput = createReactClass({
                     }
 
                     if (
+                        this.numberInput && 
                         caretPosition > 0 &&
                         oldFormattedText.length >= formattedNumber.length
                     ) {

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -198,7 +198,13 @@ export var ReactTelephoneInput = createReactClass({
         )
     },
     componentWillReceiveProps(nextProps) {
-        this.setState(this._mapPropsToState(nextProps))
+        const prevFormattedNumber = this.state.formattedNumber;
+        this.setState(this._mapPropsToState(nextProps), function() {
+            // If formatted number has changed, call on change
+            if (this.state.formattedNumber !== prevFormattedNumber) {
+                this.props.onChange(this.state.formattedNumber, this.state.selectedCountry)
+            }
+        })
     },
     componentWillUnmount() {
         document.removeEventListener('keydown', this.handleKeydown)

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -357,10 +357,7 @@ export var ReactTelephoneInput = createReactClass({
                 // only need to scrool if the dropdown list is alive
                 if (this.state.showDropDown) {
                     this.scrollTo(
-                        this.getElement(
-                            this.state.highlightCountryIndex +
-                                this.state.preferredCountries.length
-                        )
+                        this.getElement(this.state.highlightCountryIndex)
                     )
                 }
             }


### PR DESCRIPTION
Hi,

Setting element `ref`s using "String Refs" is considered [legacy API](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs) by React and is generally discouraged due to [certain issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615).

We personally ran into issues in our own setup, where the usage of string refs caused the following error to appear when `ReactTelephoneInput` was mounted in a our larger application, bundled with browserfiy:

```
removeComponentAsRefFrom(...): Only a ReactOwner can have refs. You might be removing a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```

I did not dig any deeper into the exact root cause of this, and perhaps this has something to do with the structure of our project. However, using callback refs in telephone input has solved the issue for us and it seems to be a reasonable solution, considering the currently used API will be deprecated at some point.

Thanks