### PR TITLE
Use the provided ReactDOM version instead referencing it as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jest": "^22.4.3",
     "nwb": "0.18.x",
     "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "react-test-renderer": "15.6.1",
     "regenerator-runtime": "0.10.5"
   },
@@ -66,11 +67,11 @@
     "debounce": "^1.1.0",
     "lodash.memoize": "^4.1.2",
     "prop-types": "^15.5.10",
-    "react-dom": "^16.3.2",
     "react-tiny-virtual-list": "^2.1.4"
   },
   "peerDependencies": {
-    "react": ">=0.14.0 || ^15.0.0"
+    "react": ">=0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": ">=0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "browserify-shim": {
     "classnames": "global:classNames",


### PR DESCRIPTION
This change prevents duplication of ReactDOM packages if the library is used with React 15