### PR TITLE
PR to fix tab-index

### DIFF
--- a/__tests__/__snapshots__/ReactTelephoneInput-test.js.snap
+++ b/__tests__/__snapshots__/ReactTelephoneInput-test.js.snap
@@ -4,6 +4,7 @@ exports[`react telephone input should call onEnterKeyPress prop callback on ente
 <ReactTelephoneInput
   autoComplete="tel"
   autoFormat={true}
+  buttonProps={Object {}}
   defaultCountry="us"
   disabled={false}
   flagsImagePath="flags.png"
@@ -1669,7 +1670,6 @@ exports[`react telephone input should call onEnterKeyPress prop callback on ente
       className="flag-dropdown"
       data-test-id="src_reacttelephoneinput_test_id_6"
       onKeyDown={[Function]}
-      tabIndex={0}
     >
       <button
         className="selected-flag"
@@ -1718,6 +1718,7 @@ exports[`react telephone input should call onEnterKeyPress prop callback on ente
 <ReactTelephoneInput
   autoComplete="tel"
   autoFormat={true}
+  buttonProps={Object {}}
   defaultCountry="us"
   disabled={false}
   flagsImagePath="flags.png"
@@ -3383,7 +3384,6 @@ exports[`react telephone input should call onEnterKeyPress prop callback on ente
       className="flag-dropdown"
       data-test-id="src_reacttelephoneinput_test_id_6"
       onKeyDown={[Function]}
-      tabIndex={0}
     >
       <button
         className="selected-flag"

--- a/__tests__/interaction/__snapshots__/1.js.snap
+++ b/__tests__/interaction/__snapshots__/1.js.snap
@@ -17,6 +17,7 @@ exports[`Interaction test 1 1`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="us"
     disabled={false}
     flagsImagePath="flags.png"
@@ -1682,7 +1683,6 @@ exports[`Interaction test 1 1`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -1745,6 +1745,7 @@ exports[`Interaction test 1 2`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="us"
     disabled={false}
     flagsImagePath="flags.png"
@@ -3410,7 +3411,6 @@ exports[`Interaction test 1 2`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -3477,6 +3477,7 @@ exports[`Interaction test 2 1`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -5145,7 +5146,6 @@ exports[`Interaction test 2 1`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -5213,6 +5213,7 @@ exports[`Interaction test 2 2`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -6881,7 +6882,6 @@ exports[`Interaction test 2 2`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -6948,6 +6948,7 @@ exports[`Keyboard event with searching in the list 1`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -8615,7 +8616,6 @@ exports[`Keyboard event with searching in the list 1`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -8682,6 +8682,7 @@ exports[`Keyboard event with searching in the list 2`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -10349,7 +10350,6 @@ exports[`Keyboard event with searching in the list 2`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -10416,6 +10416,7 @@ exports[`Keyboard events with escape key at the end 1`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -12083,7 +12084,6 @@ exports[`Keyboard events with escape key at the end 1`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -12150,6 +12150,7 @@ exports[`Keyboard events with escape key at the end 2`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -13817,7 +13818,6 @@ exports[`Keyboard events with escape key at the end 2`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -13884,6 +13884,7 @@ exports[`keyboard event up/down 1`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -15551,7 +15552,6 @@ exports[`keyboard event up/down 1`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"
@@ -15618,6 +15618,7 @@ exports[`keyboard event up/down 2`] = `
   <ReactTelephoneInput
     autoComplete="tel"
     autoFormat={true}
+    buttonProps={Object {}}
     defaultCountry="in"
     disabled={false}
     flagsImagePath="/flags.723494a4.png"
@@ -17285,7 +17286,6 @@ exports[`keyboard event up/down 2`] = `
         className="flag-dropdown"
         data-test-id="src_reacttelephoneinput_test_id_6"
         onKeyDown={[Function]}
-        tabIndex={0}
       >
         <button
           className="selected-flag"

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -62,6 +62,7 @@ export class ReactTelephoneInput extends Component {
     autoComplete: 'tel',
     required: false,
     inputProps: {},
+    buttonProps: {},
     listItemClassName: 'country',
     listStyle: {
       zIndex: 20,
@@ -559,10 +560,11 @@ export class ReactTelephoneInput extends Component {
     })
 
     const inputFlagClasses = `flag ${this.state.selectedCountry.iso2}`
+    const buttonProps = this.props.buttonProps
     const otherProps = this.props.inputProps
     if (this.props.inputId) {
       otherProps.id = this.props.inputId
-    }
+    }    
 
     return (
       <div
@@ -581,6 +583,7 @@ export class ReactTelephoneInput extends Component {
             data-test-id="src_reacttelephoneinput_test_id_7"
             onKeyDown={this.handleFlagKeyDown}
             type="button"
+            {...buttonProps}
           >
             <div
               className={inputFlagClasses}
@@ -639,6 +642,7 @@ ReactTelephoneInput.propTypes = {
   pattern: PropTypes.string,
   required: PropTypes.bool,
   inputProps: PropTypes.object,
+  buttonProps: PropTypes.object,
   listStyle: PropTypes.object,
   listItemClassName: PropTypes.string
 }

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -573,8 +573,6 @@ export class ReactTelephoneInput extends Component {
           className={flagViewClasses}
           onKeyDown={this.handleKeydown}
           data-test-id="src_reacttelephoneinput_test_id_6"
-          // this is crucial if we want keyboard up/down events to be heard through this div and not document.body
-          tabIndex={0}
         >
           <button
             onClick={this.handleFlagDropdownClick}


### PR DESCRIPTION
I remove the tab-index from the div container because it catches the focus and makes the component not fully navigable with the tab key.
Now, the focus moves on the button at the first tab and moves on the input at the second tab.
